### PR TITLE
Preallocate arguments with develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM base as process_engine
 # Hack to compromise priviliges error https://github.com/npm/npm/issues/17851
 RUN npm config set user 0 &&\
     npm config set unsafe-perm true
-ARG PROCESS_ENGINE_VERSION="0.1.3"
+ARG PROCESS_ENGINE_VERSION="develop"
 RUN npm install -g @process-engine/process_engine_runtime@${PROCESS_ENGINE_VERSION}
 
 # Install bpmn studio

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     stage('Build') {
       steps {
         script {
-          branch_name = "${env.BRANCH_NAME}".replace("/", "~")
+          branch_name = "${env.BRANCH_NAME}".replace("/", "-")
           image_tag = "${branch_name}-b${env.BUILD_NUMBER}";
           image_name = '5minds/bpmn-studio-bundle';
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,13 +35,15 @@ pipeline {
     stage('Build') {
       steps {
         script {
-          image_tag = "${env.BRANCH_NAME}-b${env.BUILD_NUMBER}";
+          branch_name = "${env.BRANCH_NAME}".replace("/", "~")
+          image_tag = "${branch_name}-b${env.BUILD_NUMBER}";
           image_name = '5minds/bpmn-studio-bundle';
 
-          full_image_name = "${image_name}:${image_tag}"
+          full_image_name = "${image_name}:${image_tag}";
+
           sh("docker build --build-arg NODE_IMAGE_VERSION=10-alpine \
-                           --build-arg PROCESS_ENGINE_VERSION=0.1.3 \
-                           --build-arg BPMN_STUDIO_VERSION=4.0.1-e0952e0d-b1 \
+                           --build-arg PROCESS_ENGINE_VERSION=develop \
+                           --build-arg BPMN_STUDIO_VERSION=develop \
                            --tag ${full_image_name} .");
         }
       }
@@ -58,8 +60,8 @@ pipeline {
             sh("docker push ${image_name}:latest");
 
             // Push with branch tag
-            sh("docker tag ${full_image_name} ${image_name}:${env.BRANCH_NAME}")
-            sh("docker push ${image_name}:${env.BRANCH_NAME}");
+            sh("docker tag ${full_image_name} ${image_name}:${branch_name}")
+            sh("docker push ${image_name}:${branch_name}");
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Supported tags and respective Dockerfile links
 * `latest` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
 * `master`, `master-b<build-number>` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
-* `develop`, `develop-b<build-number>` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/develop/Dockerfile)
+* `develop`, `develop-b<build-number>` [(develop/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/develop/Dockerfile)
 
 # BPMN Docker Fullimage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Supported tags and respective Dockerfile links
 * `latest` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
-* `master` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
-* `master-b<build-number>` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
+* `master`, `master-b<build-number>` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/master/Dockerfile)
+* `develop`, `develop-b<build-number>` [(master/Dockerfile)](https://github.com/process-engine/bpmn_docker_full_image/blob/develop/Dockerfile)
 
 # BPMN Docker Fullimage
 
@@ -62,7 +62,7 @@ Es ist möglich, das base image, sowie die Paketversionen anzupassen:
 
 ```shell
 docker build --build-arg NODE_IMAGE_VERSION=10-alpine \
-             --build-arg PROCESS_ENGINE_VERSION=0.1.3 \
+             --build-arg PROCESS_ENGINE_VERSION=develop \
              --build-arg BPMN_STUDIO_VERSION=develop \
              --tag 5minds/bpmn-studio-bundle:latest .
 ```


### PR DESCRIPTION
This is needed to create a working develop build with the newest npm packages.

**Changes** 
* Preallocate `PROCESS_ENGINE_VERSION` with `develop` version.
* Preallocate `BPMN_STUDIO_VERSION ` with `develop` version.
* Fix `Dockerfile`Link.