### PR TITLE
:construction_worker: Fix Wrong npm Version Target When Branch is Master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,8 +100,8 @@ node {
 
   def dockerfile_builds = [:];
 
-  def process_engine_version = branch_is_master ? 'master' : 'develop';
-  def bpmn_studio_version = branch_is_master ? 'master' : 'develop';
+  def process_engine_version = branch_is_master ? 'latest' : 'develop';
+  def bpmn_studio_version = branch_is_master ? 'latest' : 'develop';
 
   NODE_VERSIONS.each {
 


### PR DESCRIPTION
**Changes**:

1. Use latest instead of master on master branch.


**Issues**:


PR: #4